### PR TITLE
Update minecraft versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     `maven-publish`
 }
 
-val baseVersion = "0.0.1"
+val baseVersion = "0.0.2"
 val commitHash = System.getenv("COMMIT_HASH")
 val snapshotversion = "${baseVersion}-dev.$commitHash"
 

--- a/command-bungeecord/build.gradle.kts
+++ b/command-bungeecord/build.gradle.kts
@@ -26,7 +26,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("bungeecord")
     changelog.set("https://docs.simplecloud.app/changelog")

--- a/command-velocity/build.gradle.kts
+++ b/command-velocity/build.gradle.kts
@@ -28,7 +28,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("velocity")
     changelog.set("https://docs.simplecloud.app/changelog")


### PR DESCRIPTION
This pull request updates the supported versions for the `modrinth` configuration in both the `command-bungeecord` and `command-velocity` modules, adding compatibility with newer versions.

### Updates to supported versions:

* [`command-bungeecord/build.gradle.kts`](diffhunk://#diff-b7fa71165337bf8dddf1358465661112ecbb59b13fa6e5cc67a592f909702851L29-R33): Added support for versions `1.21.5` through `1.21.8` in the `modrinth` configuration.
* [`command-velocity/build.gradle.kts`](diffhunk://#diff-8aabdfd1186298bf4234b75a55e12a9eb288225dc42b6fe66c7a475591d78f5eL31-R35): Added support for versions `1.21.5` through `1.21.8` in the `modrinth` configuration.